### PR TITLE
Fixed card-skipping exploit

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -547,6 +547,7 @@ int main(int argc, char** argv) {
 
 			while ((selpos > 0) && ((nextcard = get_card(newrow, selpos-1,&selpos)) != C_EMPTY) && (card_can_be_stacked(nextcard,newcard)) ) newcard = nextcard;
 
+			if (selpos != 0) selpos += 1;
 			selrow = newrow;
 			selcard = newcard;
 		}


### PR DESCRIPTION
Shift+rowkey allows selection to jump over one card because selpos would be set 1 lower than possible as a result of get_card decrementing selpos regardless if card_can_be_stacked returns false. 

[Video of the exploit in action](https://streamable.com/pd5fa). (at first pressing _t_ normally, then Shift+_t_, then _t_ again to jump a dragon card).

This is more of a hack than a proper fix, but I'm not familiar with game logic enough to fix it properly.