### PR TITLE
Fixed the card duplication bug

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -135,6 +135,7 @@ int find_parent(int card) {
 	for (int i=0; i < 8; i++) {
 		int curcard = rows[i];
 		if (curcard == card) return C_EMPTY;
+		if (curcard == C_EMPTY) continue;  // if the row is empty, skip it
 		while (cards[curcard].next >= 0) {
 			if(cards[curcard].next == card) return curcard;
 			curcard = cards[curcard].next;


### PR DESCRIPTION
I figured out _the_ bug.

When the `find_parent` function hit an empty row (meaning `curcard` would be `-1`), it would still try to find the last card of the row with a `-1` index, which would lead to `cards[-1].next`, so something undefined would happen, and then `find_parent` would return `C_EMPTY` into `pcard` variable of `move_card`, so no card deletion would occur before copy, the card would just get copied in the end.

To fix this, we can just skip the row in `find_parent` if the top card is `C_EMPTY`.